### PR TITLE
feat: Add initial test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,38 @@ While the primary target is AWS Lambda, the Hexagonal Architecture makes local t
 | `GET`       | `/`      | Checks the health of the service endpoint. | `{"status":"UP","message":"Go serverless with OpenAPI spec!"}` |
 ---
 
+## Testing Strategy
+
+This project uses a multi-layered testing approach to ensure code quality, correctness, and reliability. The strategy is inspired by the "testing pyramid," with a focus on fast, automated tests that run within the Go toolchain.
+
+### Unit Tests
+
+* **Tool:** Go's standard `testing` package.
+* **Goal:** To test the core application logic (the "Hexagon" in our architecture) in complete isolation. This involves testing the methods on the `Server` struct directly, without any dependency on the Echo framework or AWS infrastructure. These tests are extremely fast and verify the business logic.
+
+### Integration Tests (API Layer)
+
+* **Tool:** Go's `testing` and `net/http/httptest` packages.
+* **Goal:** To test the full application stack (HTTP routing, middleware, handlers, and core logic) without deploying to AWS. These tests spin up an in-memory version of the Echo server, make real HTTP requests to it, and validate the HTTP responses (status codes, headers, and JSON bodies). This provides a fast and reliable way to verify that the entire API is functioning correctly before deployment.
+
+### End-to-End (E2E) Tests
+
+* **Tool:** Postman / cURL.
+* **Goal:** To verify that the service is working correctly after being deployed to the live AWS environment. This is a final sanity check to ensure the infrastructure (API Gateway, Lambda permissions) is configured correctly.
+
+### Architectural Decision: `httptest` vs. Karate
+
+For the integration/API testing layer, we considered external, black-box testing tools like [Karate](https://github.com/karatelabs/karate), which is excellent for testing any HTTP endpoint regardless of the backend language.
+
+However, we made the deliberate decision to use Go's native `net/http/httptest` library for this project's primary integration tests. The reasoning is as follows:
+
+* **Tight Integration:** The tests are written in Go and run with the standard `go test` command. There is no need for external runtimes (like a JVM) or dependencies.
+* **Extreme Speed:** In-memory tests execute in milliseconds, providing an incredibly fast feedback loop for developers. This encourages running tests frequently.
+* **No Deployment Necessary:** The full application stack can be validated without the time-consuming process of deploying to a remote environment.
+* **Compile-Time Safety:** The tests are part of the Go source code and benefit from the same type-safety and compile-time checks as the application itself.
+
+While Karate is a fantastic tool for true E2E testing against a deployed environment (often managed by a separate QA team), the `httptest` approach was chosen to maximize developer velocity and create a robust, self-contained safety net within the project itself.
+
 ## Architectural Decisions
 
 ### Choice of Language: Go

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ This project uses a multi-layered testing approach to ensure code quality, corre
 
 ### Architectural Decision: `httptest` vs. Karate
 
-For the integration/API testing layer, we considered external, black-box testing tools like [Karate](https://github.com/karatelabs/karate), which is excellent for testing any HTTP endpoint regardless of the backend language.
+For the integration/API testing layer, I've considered external, black-box testing tools like [Karate](https://github.com/karatelabs/karate), which is excellent for testing any HTTP endpoint regardless of the backend language.
 
-However, we made the deliberate decision to use Go's native `net/http/httptest` library for this project's primary integration tests. The reasoning is as follows:
+However, I've made the deliberate decision to use Go's native `net/http/httptest` library for this project's primary integration tests. The reasoning is as follows:
 
 * **Tight Integration:** The tests are written in Go and run with the standard `go test` command. There is no need for external runtimes (like a JVM) or dependencies.
 * **Extreme Speed:** In-memory tests execute in milliseconds, providing an incredibly fast feedback loop for developers. This encourages running tests frequently.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/akrylysov/algnhsa"

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert" // popular library for clean test assertions
+	"github.com/vifor/recetop-activity-service/api"
+)
+
+// TestHealthCheck is our in-memory integration test for the HealthCheck endpoint.
+func TestHealthCheck(t *testing.T) {
+	// 1. SETUP: Create everything needed to simulate a real HTTP request.
+	// --------------------------------------------------------------------
+	e := echo.New() // A new Echo instance
+
+	// We create a "dummy" HTTP request object.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	// We create a "recorder" which will capture the HTTP response that our handler writes.
+	rec := httptest.NewRecorder()
+
+	// We create an Echo Context, which is what our handler needs to receive.
+	c := e.NewContext(req, rec)
+
+	// Create an instance of our server, which contains the handler method.
+	s := &Server{}
+
+	// 2. EXECUTION: Call the handler method directly.
+	// --------------------------------------------------------------------
+	err := s.HealthCheck(c)
+
+	// 3. ASSERTION: Check if the results are what we expect.
+	// --------------------------------------------------------------------
+
+	// First, check that our handler didn't return a Go error.
+	assert.NoError(t, err)
+
+	// Check that the HTTP status code written to the recorder is 200 OK.
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Now, let's check the JSON body of the response.
+	var responseBody api.HealthStatus
+	err = json.Unmarshal(rec.Body.Bytes(), &responseBody)
+
+	assert.NoError(t, err, "Response body should be valid JSON")
+	assert.Equal(t, "UP", responseBody.Status)
+	assert.Equal(t, "Go serverless with OpenAPI spec!", *responseBody.Message)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,16 @@ go 1.24
 require (
 	github.com/akrylysov/algnhsa v1.1.0
 	github.com/labstack/echo/v4 v4.13.4
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
 	github.com/aws/aws-lambda-go v1.49.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
@@ -19,4 +22,5 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -31,5 +31,7 @@ golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
 golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
 golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
 golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR establishes the testing foundation for the service by introducing an automated test suite.

- Adds an in-memory integration test for the `GET /` health check endpoint using Go's standard `testing` and `net/http/httptest` packages.
- Uses the `stretchr/testify` library for clear and readable assertions.
- Includes updated `README.md` documentation detailing the project's multi-layered testing strategy.

This provides a safety net for future development and refactoring.